### PR TITLE
031 get global state with the usecontext hook

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -37,11 +37,8 @@ function App() {
 							element={
 								<>
 									<FeedbackForm handleAdd={addFeedback} />
-									<FeedbackStats feedback={feedback} />
-									<FeedbackList
-										feedback={feedback}
-										handleDelete={deleteFeedback}
-									/>
+									<FeedbackStats />
+									<FeedbackList handleDelete={deleteFeedback} />
 								</>
 							}
 						/>

--- a/src/components/FeedbackList.jsx
+++ b/src/components/FeedbackList.jsx
@@ -1,8 +1,11 @@
 import { motion, AnimatePresence } from 'framer-motion';
-import PropTypes from 'prop-types';
+import { useContext } from 'react';
 import FeedbackItem from './FeedbackItem';
+import FeedbackContext from '../context/FeedbackContext';
 
-function FeedbackList({ feedback, handleDelete }) {
+function FeedbackList({ handleDelete }) {
+	const { feedback } = useContext(FeedbackContext);
+
 	if (!feedback || feedback.length === 0) {
 		return <p>No Feedback Yet...</p>;
 	}
@@ -37,15 +40,5 @@ function FeedbackList({ feedback, handleDelete }) {
 		</div>
 	);
 }
-
-FeedbackList.propTypes = {
-	feedback: PropTypes.arrayOf(
-		PropTypes.shape({
-			id: PropTypes.number.isRequired,
-			text: PropTypes.string.isRequired,
-			rating: PropTypes.number.isRequired,
-		})
-	),
-};
 
 export default FeedbackList;

--- a/src/components/FeedbackStats.jsx
+++ b/src/components/FeedbackStats.jsx
@@ -1,6 +1,9 @@
-import PropTypes from 'prop-types';
+import { useContext } from 'react';
+import FeedbackContext from '../context/FeedbackContext';
 
-function FeedbackStats({ feedback }) {
+function FeedbackStats() {
+	const { feedback } = useContext(FeedbackContext);
+
 	// Calculate Ratings Average
 	let average =
 		feedback.reduce((acc, cur) => {
@@ -16,9 +19,5 @@ function FeedbackStats({ feedback }) {
 		</div>
 	);
 }
-
-FeedbackStats.propTypes = {
-	feedback: PropTypes.array.isRequired,
-};
 
 export default FeedbackStats;


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 31 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Remove `feedback` Prop From Components
  - `feedback` state now in context, removed prop from `FeedbackStats`
  - `feedback` state now in context, removed prop from `FeedbackList`
- Update `FeedbackList` Component To Use Context API
  - Removed `prop-types` from `FeedbackList` component
  - Removed prop validation from `FeedbackList` component
  - Import `useContext` hook
  - Import `FeedbackContext` component to use context
  - Removed `feedback` prop from `FeedbackList` component
  - Extract `feedback` state from `FeedbackContext` using hook
- Update `FeedbackStats` Component, Use Context API
  - Removed `prop-types` from `FeedbackStats` component
  - Removed prop validation from `FeedbackStats` component
  - Import `useContext` hook
  - Import `FeedbackContext` component to use context
  - Removed `feedback` prop from `FeedbackStat` component
  - Extract `feedback` state from `FeedbackContext` using hook

Minimal testing was done by way of changing basic code and seeing those changes reflected in the UI.

Resolves #46 