### PR TITLE
033 edit feedback event

### DIFF
--- a/src/components/FeedbackItem.jsx
+++ b/src/components/FeedbackItem.jsx
@@ -1,17 +1,20 @@
-import { FaTimes } from 'react-icons/fa';
+import { FaTimes, FaEdit } from 'react-icons/fa';
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Card from './shared/Card';
 import FeedbackContext from '../context/FeedbackContext';
 
 function FeedbackItem({ item }) {
-	const { deleteFeedback } = useContext(FeedbackContext);
+	const { deleteFeedback, editFeedback } = useContext(FeedbackContext);
 
 	return (
 		<Card>
 			<div className='num-display'>{item.rating}</div>
 			<button onClick={() => deleteFeedback(item.id)} className='close'>
 				<FaTimes color='purple' />
+			</button>
+			<button onClick={() => editFeedback(item)} className='edit'>
+				<FaEdit color='purple' />
 			</button>
 			<div className='text-display'>{item.text}</div>
 		</Card>

--- a/src/context/FeedbackContext.js
+++ b/src/context/FeedbackContext.js
@@ -22,15 +22,30 @@ export const FeedbackProvider = ({ children }) => {
 		},
 	]);
 
+	const [feedbackEdit, setFeedbackEdit] = useState({
+		item: {},
+		edit: false,
+	});
+
+	// Delete Feedback
 	const deleteFeedback = (id) => {
 		if (window.confirm('Are you sure you want to delete this feedback?')) {
 			setFeedback(feedback.filter((item) => item.id !== id));
 		}
 	};
 
+	// Add Feedback
 	const addFeedback = (newFeedback) => {
 		newFeedback.id = uuidv4();
 		setFeedback([newFeedback, ...feedback]);
+	};
+
+	// Set Item To Be Updated
+	const editFeedback = (item) => {
+		setFeedbackEdit({
+			item,
+			edit: true,
+		});
 	};
 
 	return (
@@ -39,6 +54,7 @@ export const FeedbackProvider = ({ children }) => {
 				feedback,
 				deleteFeedback,
 				addFeedback,
+				editFeedback,
 			}}>
 			{children}
 		</FeedbackContext.Provider>


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 33 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Add `editFeedback` Icon, Base Functionality
  - Import `FaEdit` from `react-icons`
  - Extract `editFeedback` function from global state/context API
  - Add edit icon button with `editFeedback` onClick action
- Add New `useState` Hook For Editing Feedback
  - Create useState hook for editing feedback, setting default state
  - Add comment to `deleteFeedback` function
  - Add comment to `addFeedback` function
  - Create `editFeedback` function for feedback editing
  - Export `editFeedback` function in global state/context API

Minimal testing was done by way of changing basic code and seeing those changes reflected in the UI.

Resolves #48 