### PR TITLE
034 side effects with useeffect

### DIFF
--- a/src/components/FeedbackForm.jsx
+++ b/src/components/FeedbackForm.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import RatingSelect from './RatingSelect';
 import Card from './shared/Card';
 import Button from './shared/Button';
@@ -10,7 +10,15 @@ function FeedbackForm() {
 	const [btnDisabled, setBtnDisabled] = useState(true);
 	const [message, setMessage] = useState('');
 
-	const { addFeedback } = useContext(FeedbackContext);
+	const { addFeedback, feedbackEdit } = useContext(FeedbackContext);
+
+	useEffect(() => {
+		if(feedbackEdit.edit === true) {
+			setBtnDisabled(false)
+			setText(feedbackEdit.item.text)
+			setRating(feedbackEdit.item.rating)
+		}
+	}, [feedbackEdit])
 
 	const handleTextChange = (e) => {
 		if (text === '') {

--- a/src/components/RatingSelect.jsx
+++ b/src/components/RatingSelect.jsx
@@ -1,7 +1,14 @@
-import { useState } from 'react';
+import { useState, useContext, useEffect } from 'react';
+import FeedbackContext from '../context/FeedbackContext';
 
 function RatingSelect({ select }) {
 	const [selected, setSelected] = useState(10);
+
+	const { feedbackEdit } = useContext(FeedbackContext);
+
+	useEffect(() => {
+		setSelected(feedbackEdit.item.rating);
+	}, [feedbackEdit]);
 
 	const handleChange = (e) => {
 		setSelected(+e.currentTarget.value);

--- a/src/context/FeedbackContext.js
+++ b/src/context/FeedbackContext.js
@@ -52,6 +52,7 @@ export const FeedbackProvider = ({ children }) => {
 		<FeedbackContext.Provider
 			value={{
 				feedback,
+				feedbackEdit,
 				deleteFeedback,
 				addFeedback,
 				editFeedback,


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 34 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Add `feedbackEdit` State To Context API For Export
- Add `useEffect` Hook For `feedbackEdit`
  - Import `useEffect` hook
  - Extract `feedbackEdit` from `FeedbackContext` in global state
  - Create `useEffect` hook
    - Hook checks to see if `edit` boolean is True
    - If True, brings feedback into text box for editing
- Add `useEffect` Hook + `FeedbackContext` For Edit
  - Import `useContext`, `useEffect` hook
  - Import `FeedbackContext` for component to access global state
  - Extract `feedbackEdit` from global state/context API
  - Create `useEffect` hook to update rating based on extracted state

Minimal testing was done by way of changing basic code and seeing those changes reflected in the UI.

Resolves #49 