### PR TITLE
035 update feedback item

### DIFF
--- a/src/components/FeedbackForm.jsx
+++ b/src/components/FeedbackForm.jsx
@@ -10,15 +10,16 @@ function FeedbackForm() {
 	const [btnDisabled, setBtnDisabled] = useState(true);
 	const [message, setMessage] = useState('');
 
-	const { addFeedback, feedbackEdit } = useContext(FeedbackContext);
+	const { addFeedback, feedbackEdit, updateFeedback } =
+		useContext(FeedbackContext);
 
 	useEffect(() => {
-		if(feedbackEdit.edit === true) {
-			setBtnDisabled(false)
-			setText(feedbackEdit.item.text)
-			setRating(feedbackEdit.item.rating)
+		if (feedbackEdit.edit === true) {
+			setBtnDisabled(false);
+			setText(feedbackEdit.item.text);
+			setRating(feedbackEdit.item.rating);
 		}
-	}, [feedbackEdit])
+	}, [feedbackEdit]);
 
 	const handleTextChange = (e) => {
 		if (text === '') {
@@ -42,8 +43,11 @@ function FeedbackForm() {
 				text,
 				rating,
 			};
-
-			addFeedback(newFeedback);
+			if (feedbackEdit.edit === true) {
+				updateFeedback(feedbackEdit.item.id, newFeedback);
+			} else {
+				addFeedback(newFeedback);
+			}
 
 			setText('');
 		}

--- a/src/context/FeedbackContext.js
+++ b/src/context/FeedbackContext.js
@@ -27,14 +27,14 @@ export const FeedbackProvider = ({ children }) => {
 		edit: false,
 	});
 
-	// Delete Feedback
+	// Delete Feedback Item
 	const deleteFeedback = (id) => {
 		if (window.confirm('Are you sure you want to delete this feedback?')) {
 			setFeedback(feedback.filter((item) => item.id !== id));
 		}
 	};
 
-	// Add Feedback
+	// Add Feedback Item
 	const addFeedback = (newFeedback) => {
 		newFeedback.id = uuidv4();
 		setFeedback([newFeedback, ...feedback]);
@@ -48,6 +48,13 @@ export const FeedbackProvider = ({ children }) => {
 		});
 	};
 
+	// Update Feedback Item
+	const updateFeedback = (id, updItem) => {
+		setFeedback(
+			feedback.map((item) => (item.id === id ? { ...item, ...updItem } : item))
+		);
+	};
+
 	return (
 		<FeedbackContext.Provider
 			value={{
@@ -56,6 +63,7 @@ export const FeedbackProvider = ({ children }) => {
 				deleteFeedback,
 				addFeedback,
 				editFeedback,
+				updateFeedback,
 			}}>
 			{children}
 		</FeedbackContext.Provider>


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 35 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Add `updateFeedback` Function, Update Comments
  - Update comments for greater specificity
  - Create `updateFeedback` function to update the feedback in the app UI
  - Export `updateFeedback` function into context API/global state
- Update `FeedbackForm` Component, Allow Item Update
  - Extract `updateFeedback` function from context API/global state
  - Update `useEffect` formatting
  - Create conditional in `handleSubmit` that checks if `edit` = true
    - `edit` = true, call `updateFeedback` function and update feedback
    - `edit` != true, call `addFeedback` function and create feedback

Minimal testing was done by way of changing basic code and seeing those changes reflected in the UI.

Resolves #50 