### PR TITLE
042 add feedback and setting a proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "udemy-feedback-app-brad-traversy",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:5001",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",

--- a/src/context/FeedbackContext.js
+++ b/src/context/FeedbackContext.js
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import { createContext, useState, useEffect } from 'react';
 
 const FeedbackContext = createContext();
@@ -32,9 +31,12 @@ export const FeedbackProvider = ({ children }) => {
 	};
 
 	// Add Feedback Item
-	const addFeedback = (newFeedback) => {
-		newFeedback.id = uuidv4();
-		setFeedback([newFeedback, ...feedback]);
+	const addFeedback = async (newFeedback) => {
+		const response = await fetch('/feedback', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+	body: JSON.stringify(newFeedback) })
+		const data = await response.json();
+
+		setFeedback([data, ...feedback]);
 	};
 
 	// Set Item To Be Updated

--- a/src/context/FeedbackContext.js
+++ b/src/context/FeedbackContext.js
@@ -12,14 +12,12 @@ export const FeedbackProvider = ({ children }) => {
 	});
 
 	useEffect(() => {
-		console.log(123);
+		fetchFeedback();
 	}, []);
 
 	// Fetch All Feedback Items
 	const fetchFeedback = async () => {
-		const response = await fetch(
-			`http://localhost:5001/feedback?_sort=id&_order=desc`
-		);
+		const response = await fetch(`/feedback?_sort=id&_order=desc`);
 		const data = await response.json();
 
 		setFeedback(data);


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 42 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Add `proxy` To `package.json` For Concise BE Calls
- Remove `http` To Use proxy, Amend `useEffect`
  - Amend `useEffect`, forgot to switch `console.log` with `fetchFeedack`
  - Removed `http` portion of `fetch` to make use of new proxy
- Remove `uuid`, Update `addFeedback` To Fetch
  - Remove the package import of `uuid`
  - Remove setting the `id` of the feedback using `uuid` import
  - Update `addFeedback` to make use of the `fetch` API

Testing was performed by making the changes and then restarting the `dev` server and attempting to add a Feedback Item to the list; was able to add successfully.

Resolves #61 